### PR TITLE
`__eq__` based on same class and name for `mm.Term` abstract class

### DIFF
--- a/micromagneticmodel/abstract/container.py
+++ b/micromagneticmodel/abstract/container.py
@@ -138,7 +138,12 @@ class Container(metaclass=abc.ABCMeta):
         True
         >>> mm.Zeeman(H=(0, 0, 1)) in energy
         False
+        >>> # A check with a different term is only ``True`` if all attributes
+        >>> # (e.g. exchange constant ``A`` and ``name``) match one of the terms in
+        >>> # the energy equation
         >>> mm.Exchange(A=5e-11) in energy
+        False
+        >>> mm.Exchange(A=1e-12, name="my_exchange") in energy
         False
 
         """
@@ -318,8 +323,7 @@ class Container(metaclass=abc.ABCMeta):
 
         """
         result = self.__class__()
-        for term in self:
-            result._terms.append(term)
+        result._terms.extend(self)
 
         if isinstance(other, self._term_class):
             if any(
@@ -327,8 +331,9 @@ class Container(metaclass=abc.ABCMeta):
                 for term in self._terms
             ):
                 msg = (
-                    f"Cannot have same class {other.__class__} and name {other.name} "
-                    "in the container. Please provide a different 'name' for the term."
+                    f"There is already a term of type {other.__class__} with  name "
+                    f"'{other.name}' in {self.__class__}. Please provide a different "
+                    f"name for {other}."
                 )
                 raise ValueError(msg)
             else:
@@ -394,12 +399,11 @@ class Container(metaclass=abc.ABCMeta):
 
         """
         result = self.__class__()
-        for term in self:
-            result._terms.append(term)
+        result._terms.extend(self)
 
         if isinstance(other, self._term_class):
             if other not in result:
-                msg = f"Term {other.__class__} not in {self.__class__}."
+                msg = f"Term {other} not in {self.__class__}."
                 raise ValueError(msg)
             else:
                 result._terms.remove(other)

--- a/micromagneticmodel/abstract/container.py
+++ b/micromagneticmodel/abstract/container.py
@@ -138,9 +138,11 @@ class Container(metaclass=abc.ABCMeta):
         True
         >>> mm.Zeeman(H=(0, 0, 1)) in energy
         False
-        >>> # A check with a different term is only ``True`` if all attributes
-        >>> # (e.g. exchange constant ``A`` and ``name``) match one of the terms in
-        >>> # the energy equation
+
+        A check with a different term is only ``True`` if all attributes
+        (e.g. exchange constant ``A`` and ``name``) match one of the terms in
+        the energy equation
+
         >>> mm.Exchange(A=5e-11) in energy
         False
         >>> mm.Exchange(A=1e-12, name="my_exchange") in energy

--- a/micromagneticmodel/abstract/container.py
+++ b/micromagneticmodel/abstract/container.py
@@ -268,12 +268,11 @@ class Container(metaclass=abc.ABCMeta):
         True
 
         """
-        if not isinstance(other, self.__class__):
-            return False
-        if len(self) == len(other) and all(term in self for term in other):
-            return True
-        else:
-            return False
+        return (
+            isinstance(other, self.__class__)
+            and len(self) == len(other)
+            and all(term in self for term in other)
+        )
 
     def __add__(self, other):
         """Binary ``+`` operator.

--- a/micromagneticmodel/abstract/container.py
+++ b/micromagneticmodel/abstract/container.py
@@ -138,9 +138,8 @@ class Container(metaclass=abc.ABCMeta):
         True
         >>> mm.Zeeman(H=(0, 0, 1)) in energy
         False
-        >>> # Looks for a term of the same type only.
         >>> mm.Exchange(A=5e-11) in energy
-        True
+        False
 
         """
         return item in self._terms
@@ -324,10 +323,17 @@ class Container(metaclass=abc.ABCMeta):
             result._terms.append(term)
 
         if isinstance(other, self._term_class):
-            if other in result:
-                msg = f"Cannot have two {other.__class__} terms in the container."
+            if any(
+                isinstance(other, term.__class__) and other.name == term.name
+                for term in self._terms
+            ):
+                msg = (
+                    f"Cannot have same class {other.__class__} and name {other.name} "
+                    "in the container. Please provide a different 'name' for the term."
+                )
                 raise ValueError(msg)
-            result._terms.append(other)
+            else:
+                result._terms.append(other)
         elif isinstance(other, self.__class__):
             for term in other:
                 result += term

--- a/micromagneticmodel/abstract/container.py
+++ b/micromagneticmodel/abstract/container.py
@@ -143,11 +143,7 @@ class Container(metaclass=abc.ABCMeta):
         True
 
         """
-        for term in self:
-            if term.name == item.name:
-                return True
-        else:
-            return False
+        return item in self._terms
 
     def __getattr__(self, attr):
         """Accessing an individual term from the container.
@@ -400,9 +396,8 @@ class Container(metaclass=abc.ABCMeta):
             if other not in result:
                 msg = f"Term {other.__class__} not in {self.__class__}."
                 raise ValueError(msg)
-            for term in result:
-                if term.name == other.name:
-                    result._terms.remove(term)
+            else:
+                result._terms.remove(other)
         elif isinstance(other, self.__class__):
             for term in other:
                 result -= term

--- a/micromagneticmodel/abstract/term.py
+++ b/micromagneticmodel/abstract/term.py
@@ -64,12 +64,8 @@ class Term(Abstract):
         False
 
         """
-        if (
-            isinstance(other, self.__class__) and self.name == other.name
-        ):  # To take into account user defined names
-            return True
-        else:
-            return False
+        if isinstance(other, self.__class__):
+            return self.name == other.name
 
     def __add__(self, other):
         """Binary ``+`` operator.

--- a/micromagneticmodel/abstract/term.py
+++ b/micromagneticmodel/abstract/term.py
@@ -65,9 +65,7 @@ class Term(Abstract):
 
         """
         if isinstance(other, self.__class__) and self.name == other.name:
-            attrs = {attr: val for attr, val in self}
-            attrs_other = {attr: val for attr, val in other}
-            return attrs == attrs_other
+            return dict(self) == dict(other)
         else:
             return False
 

--- a/micromagneticmodel/abstract/term.py
+++ b/micromagneticmodel/abstract/term.py
@@ -50,8 +50,8 @@ class Term(Abstract):
         ...
         >>> exchange == exchange
         True
-        >>> exchange == mm.Exchange(A=5e-11)  # only class is checked
-        True
+        >>> exchange == mm.Exchange(A=5e-11)
+        False
         >>> zeeman != exchange
         True
         >>> zeeman == exchange
@@ -64,7 +64,12 @@ class Term(Abstract):
         False
 
         """
-        return isinstance(other, self.__class__) and self.name == other.name
+        if isinstance(other, self.__class__) and self.name == other.name:
+            attrs = {attr: val for attr, val in self}
+            attrs_other = {attr: val for attr, val in other}
+            return attrs == attrs_other
+        else:
+            return False
 
     def __add__(self, other):
         """Binary ``+`` operator.

--- a/micromagneticmodel/abstract/term.py
+++ b/micromagneticmodel/abstract/term.py
@@ -64,8 +64,7 @@ class Term(Abstract):
         False
 
         """
-        if isinstance(other, self.__class__):
-            return self.name == other.name
+        return isinstance(other, self.__class__) and self.name == other.name
 
     def __add__(self, other):
         """Binary ``+`` operator.

--- a/micromagneticmodel/abstract/term.py
+++ b/micromagneticmodel/abstract/term.py
@@ -64,7 +64,9 @@ class Term(Abstract):
         False
 
         """
-        if isinstance(other, self.__class__):
+        if (
+            isinstance(other, self.__class__) and self.name == other.name
+        ):  # To take into account user defined names
             return True
         else:
             return False

--- a/micromagneticmodel/energy/zeeman.py
+++ b/micromagneticmodel/energy/zeeman.py
@@ -193,7 +193,9 @@ class Zeeman(EnergyTerm):
                 r"-\mu_{0}M_\text{s} \mathbf{m} \cdot \mathbf{H}\, "
                 r"\text{sinc}[2 \pi f (t-t_{0})]"
             )
-        elif hasattr(self, "name") and self.name != "zeeman":  # Check for user defined name
+        elif (
+            self.name != self.__class__.__name__.lower()
+        ):  # Check for user defined name
             return (
                 r"-\mu_{0}M_\text{s} \mathbf{m} \cdot \mathbf{H}_\text"
                 + f"{{{self.name}}}"

--- a/micromagneticmodel/energy/zeeman.py
+++ b/micromagneticmodel/energy/zeeman.py
@@ -193,6 +193,12 @@ class Zeeman(EnergyTerm):
                 r"-\mu_{0}M_\text{s} \mathbf{m} \cdot \mathbf{H}\, "
                 r"\text{sinc}[2 \pi f (t-t_{0})]"
             )
+        elif hasattr(self, "name") and self.name != "zeeman":  # Check for user defined name
+            return (
+                r"-\mu_{0}M_\text{s} \mathbf{m} \cdot \mathbf{H}_\text"
+                + f"{{{self.name}}}"
+            )
+
         else:
             return r"-\mu_{0}M_\text{s} \mathbf{m} \cdot \mathbf{H}"
 

--- a/micromagneticmodel/tests/test_dynamics.py
+++ b/micromagneticmodel/tests/test_dynamics.py
@@ -114,11 +114,12 @@ class TestDynamics:
         check_container(container)
         assert "alpha" in container._repr_latex_()
         assert len(container) == 2
-        assert mm.Damping() in container  # term of the same type present
+        assert mm.Damping() not in container
+        assert mm.Damping(alpha={"r1": 1, "r2": 0.5}) in container
         assert "damping" in dir(container)
         assert len(list(container)) == 2
 
-        container -= mm.Damping()
+        container -= mm.Damping(alpha={"r1": 1, "r2": 0.5})
         check_container(container)
         assert len(container) == 1
         assert mm.Damping() not in container

--- a/micromagneticmodel/tests/test_energy.py
+++ b/micromagneticmodel/tests/test_energy.py
@@ -141,10 +141,12 @@ class TestEnergy:
         check_container(container)
         assert "D" in container._repr_latex_()
         assert len(container) == 2
-        assert mm.Zeeman(H=(0, 0, 1e6)) in container  # same type term present?
+        assert mm.Zeeman(H=(0, 0, 1e6)) not in container  # Different values of H
         assert "dmi" in dir(container)
         assert len(list(container)) == 2
 
+        with pytest.raises(ValueError):
+            container -= mm.DMI(D=1e-3, crystalclass="Cnv")
         container -= mm.DMI(D=1e-3, crystalclass="T")
         check_container(container)
         assert len(container) == 1
@@ -161,6 +163,7 @@ class TestEnergy:
         term1 = mm.UniaxialAnisotropy(K=1e6, u=(0, 0, 1))
         term2 = mm.UniaxialAnisotropy(K=2e6, u=(0, 1, 0))
         term3 = mm.UniaxialAnisotropy(K=2e6, u=(1, 0, 0), name="ua2")
+        term4 = mm.UniaxialAnisotropy(K=3e6, u=(0, 1, 0), name="ua3")
 
         with pytest.raises(ValueError):
             container = term1 + term2
@@ -172,6 +175,14 @@ class TestEnergy:
         assert term3 in container
         assert container.uniaxialanisotropy.K == 1e6
         assert container.ua2.K == 2e6
+
+        container_diff_name = term1 + term3 + term4
+        check_container(container_diff_name)
+        container_diff_name -= container_diff_name.ua3
+        check_container(container_diff_name)
+        assert term4 not in container_diff_name
+        assert term3 in container_diff_name
+        assert term1 in container_diff_name
 
     def test_energy_and_energy_density(self):
         container = self.dmi + self.zeeman  # single term is not allowed


### PR DESCRIPTION
This helps in differentiating between two terms of the same class but with different names. This is particularly useful for the `mm.Container.__sub__` method.

I encountered a problem when removing an **additional** Zeeman field with `name=pulse` from `system.energy` like `system.energy -= pulse` where `pulse = mm.Zeeman(H=H_pulse, name="Pulse")`. The subtraction would remove the first term of `mm.Zeeman` class which was a constant external field and not the `pulse`.