### PR TITLE
More flexibility when scheduling runs

### DIFF
--- a/micromagneticmodel/driver.py
+++ b/micromagneticmodel/driver.py
@@ -43,6 +43,10 @@ class ExternalDriver(Driver):
         """Call the external package."""
 
     @abc.abstractmethod
+    def _schedule_commands(self, system, runner):
+        """Return a list of commands to append to the scheduling script."""
+
+    @abc.abstractmethod
     def _read_data(self, system):
         """Update system with simulation output (magnetisation and scalar data)."""
 
@@ -276,11 +280,11 @@ class ExternalDriver(Driver):
                 header = f.read()
         else:
             header = header
-        run_cmd = self._call(system=system, runner=runner, dry_run=True)
+        run_commands = self._schedule_commands(system=system, runner=runner)
         with open(script_name, "wt", encoding="utf-8") as f:
             f.write(header)
             f.write("\n")
-            f.write(" ".join(run_cmd))
+            f.write("\n".join(run_commands))
 
     def _write_info_json(self, system, **kwargs):
         info = {}

--- a/micromagneticmodel/driver.py
+++ b/micromagneticmodel/driver.py
@@ -39,7 +39,7 @@ class ExternalDriver(Driver):
         """Write input files required for the external package."""
 
     @abc.abstractmethod
-    def _call(self, system, runner, dry_run=False, **kwargs):
+    def _call(self, system, runner, **kwargs):
         """Call the external package."""
 
     @abc.abstractmethod

--- a/micromagneticmodel/runner.py
+++ b/micromagneticmodel/runner.py
@@ -21,7 +21,6 @@ class ExternalRunner(abc.ABC):
         verbose=1,
         total=None,
         glob_name="",
-        dry_run=False,
         **kwargs,
     ):
         """Call an external simulation package by passing ``argstr`` to it.
@@ -55,11 +54,6 @@ class ExternalRunner(abc.ABC):
             package writes during the simulation. This information is used to update the
             progress bar.
 
-        dry_run : bool, optional
-
-            If ``dry_run=True`` this method returns the command to call the external
-            package without calling it. Defaults to ``False``.
-
         Raises
         ------
         RuntimeError
@@ -68,17 +62,11 @@ class ExternalRunner(abc.ABC):
 
         Returns
         -------
-        int, str
+        int
 
-            If ``dry_run=False`` and when the run was successful, ``0`` is returned. If
-            ``dry_run=True`` the command to call the external package is returned.
+            If the run was successful, ``0`` is returned.
 
         """
-        if dry_run:
-            return self._call(
-                argstr=argstr, need_stderr=need_stderr, dry_run=True, **kwargs
-            )
-
         if verbose >= 2 and total:
             context = uu.progress.bar(
                 total=total,

--- a/micromagneticmodel/runner.py
+++ b/micromagneticmodel/runner.py
@@ -64,7 +64,7 @@ class ExternalRunner(abc.ABC):
         -------
         int
 
-            If the run was successful, ``0`` is returned.
+            Return code of the runner, 0 if the run was successful.
 
         """
         if verbose >= 2 and total:

--- a/micromagneticmodel/tests/test_driver.py
+++ b/micromagneticmodel/tests/test_driver.py
@@ -35,14 +35,17 @@ class MyExternalDriver(mm.ExternalDriver):
 
     def _call(self, system, runner, dry_run=False, **kwargs):
         if dry_run:
-            # Python is used to test/simulate schedule during tests because there
-            # typically is no scheduling system and Python is always available.
-            # Therefore, dry_run must return a Python comment that can be added to the
-            # schedule script without breaking the execution.
-            return ["#", "run", "command", "line"]
+            raise NotImplementedError("This functionality will be removed.")
         with open(f"{system.name}.input", "rt", encoding="utf-8") as f:
             factor = int(f.read())
         (factor * system.m).to_file("output.omf")
+
+    def _schedule_commands(self, system, runner):
+        # Python is used to test/simulate schedule during tests because there
+        # typically is no scheduling system and Python is always available.
+        # Therefore, dry_run must return a Python comment that can be added to the
+        # schedule script without breaking the execution.
+        return ["# run command line"]
 
     def _read_data(self, system):
         system.m = df.Field.from_file("output.omf")

--- a/micromagneticmodel/tests/test_driver.py
+++ b/micromagneticmodel/tests/test_driver.py
@@ -33,9 +33,7 @@ class MyExternalDriver(mm.ExternalDriver):
             f.write(str(-1))  # factor -1 used to invert magnetisation direction in call
         self._write_info_json(system, **kwargs)
 
-    def _call(self, system, runner, dry_run=False, **kwargs):
-        if dry_run:
-            raise NotImplementedError("This functionality will be removed.")
+    def _call(self, system, runner, **kwargs):
         with open(f"{system.name}.input", "rt", encoding="utf-8") as f:
             factor = int(f.read())
         (factor * system.m).to_file("output.omf")
@@ -43,7 +41,7 @@ class MyExternalDriver(mm.ExternalDriver):
     def _schedule_commands(self, system, runner):
         # Python is used to test/simulate schedule during tests because there
         # typically is no scheduling system and Python is always available.
-        # Therefore, dry_run must return a Python comment that can be added to the
+        # Therefore, we return a Python comment that can be added to the
         # schedule script without breaking the execution.
         return ["# run command line"]
 

--- a/micromagneticmodel/tests/test_runner.py
+++ b/micromagneticmodel/tests/test_runner.py
@@ -23,7 +23,7 @@ class MyRunner(mm.ExternalRunner):
 
 def test_call(capsys):
     runner = MyRunner()
-    command = runner.call("argstr", dry_run=True)
+    command = runner._call("argstr", dry_run=True)
     assert command == ["my_package", "argstr", "command", "line"]
 
     runner.call("argstr")


### PR DESCRIPTION
A separate `_schedule_commands` methods is now used to create all required calculator calls for a script. This is required to take calculator specific details into account, e.g. OOMMF requires calls to launchhost and kill in addition to the "actual" call.

With these changes the `dry_run` option is not any longer needed in the public interface and therefore I removed it.